### PR TITLE
Use a custom binding layer for ZLL's commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vs
 bin/
 obj/
 reference/

--- a/zone-loot-list/Scripts/General/BasePopup.cs
+++ b/zone-loot-list/Scripts/General/BasePopup.cs
@@ -1,14 +1,76 @@
+using ConsoleLib.Console;
+using HarmonyLib;
 using System.Collections.Generic;
 using System.Linq;
+using XRL.UI;
 
 namespace Plaidman.AnEyeForValue.Menus {
 	public enum SortType { Weight, Value };
 	public enum PickupType { Single, Multi };
 
-	public class BasePopup {
+	// used for classic UI popups
+	// ref: XRL.UI.Popup
+	[UIView("ZoneLootPopup", false, false, false, "ZoneLootNav", null, false, 0, false)]
+	// used for modern UI popups
+	// ref: Qud.UI.PopupMessage
+	[UIView("DynamicZonePopupMessage", false, false, false, "ZoneLootNav", null, false, 0, false, IgnoreForceFullscreen = true)]
+	[UIView("PopupZoneMessage", false, false, false, "ZoneLootNav", "PopupMessage", false, 0, false, IgnoreForceFullscreen = true, UICanvasHost = 1)]
+	[HarmonyPatch]
+	public class BasePopup : IWantsTextConsoleInit {
 		public SortType CurrentSortType;
 		private Dictionary<SortType, List<InventoryItem>> ItemListCache;
 		protected Dictionary<SortType, IComparer<InventoryItem>> Comparers;
+
+		internal static bool callRealFunc = false;
+
+		[HarmonyPatch(typeof(GameManager), nameof(GameManager.PushGameView))]
+		[HarmonyPrefix]
+		static bool PushGV_Prefix(ref GameManager __instance, string NewView, bool bHard)
+        {
+			if (callRealFunc)
+            {
+				return true;
+            }
+			UnityEngine.Debug.LogError("PushGameView - Prefix - NewView: " + NewView);
+			if (NewView == "PopupMessage" && bHard)
+            {
+				callRealFunc = true;
+				GameManager.Instance.PushGameView("PopupZoneMessage", bHard);
+				return false;
+            }
+			else if (NewView == "DynamicPopupMessage" && bHard)
+            {
+				callRealFunc = true;
+				GameManager.Instance.PushGameView("DynamicZonePopupMessage", bHard);
+				return false;
+			}
+			else if (NewView == "Popup:Choice" && bHard)
+            {
+				callRealFunc = true;
+				GameManager.Instance.PushGameView("ZoneLootPopup", bHard);
+				return false;
+			}
+			return true;
+        }
+
+		[HarmonyPatch(typeof(GameManager), nameof(GameManager.PushGameView))]
+		[HarmonyPostfix]
+		static void PushGV_Postfix(ref GameManager __instance, string NewView, bool bHard)
+        {
+			if (callRealFunc)
+            {
+				callRealFunc = false;
+				GameManager.ViewInfo check = GameManager.Instance.GetViewData(NewView);
+				UnityEngine.Debug.LogError("PushGameView - NavCategory: " + check.NavCategory);
+			}
+        }
+
+		// copied from XRL.UI.Popup
+		public void Init(TextConsole TextConsole_, ScreenBuffer ScreenBuffer_)
+		{
+			Popup._TextConsole = TextConsole_;
+			Popup._ScreenBuffer = ScreenBuffer_;
+		}
 
 		protected void ResetCache() {
 			ItemListCache = new() {

--- a/zone-loot-list/Scripts/General/BasePopup.cs
+++ b/zone-loot-list/Scripts/General/BasePopup.cs
@@ -1,5 +1,6 @@
 using ConsoleLib.Console;
 using HarmonyLib;
+using Qud.UI;
 using System.Collections.Generic;
 using System.Linq;
 using XRL.UI;
@@ -8,13 +9,21 @@ namespace Plaidman.AnEyeForValue.Menus {
 	public enum SortType { Weight, Value };
 	public enum PickupType { Single, Multi };
 
-	// used for classic UI popups, ref: XRL.UI.Popup
-	[UIView("ZoneLootPopup", false, false, false, "ZoneLootNav", null, false, 0, false)]
-	// used for modern UI popups, ref: Qud.UI.PopupMessage
-	// using "PopupMessage" for the UICanvas parameter of ZoneLootPopupMessage is intentional! Quote from the documentation (found on CoQ Discord):
-	// UICanvas - The name of the UI Canvas (Unity) GameObject which should be displayed when this view is active
-	[UIView("ZoneLootDynamicPopupMessage", false, false, false, "ZoneLootNav", null, false, 0, false, IgnoreForceFullscreen = true)]
-	[UIView("ZoneLootPopupMessage", false, false, false, "ZoneLootNav", "PopupMessage", false, 0, false, IgnoreForceFullscreen = true, UICanvasHost = 1)]
+	/* This UIView is used for classic UI popups, ref: GameManager::_ViewData["*Default"]
+	 * Note that most popups (including the one in Popup::PickOption()) do NOT use the Popup class' own UIView (the one with ID = "Popup")!
+	 * Don't get confused by one of the "NewView" parameters to PushGameView() ("Popup:Choice")!
+	 * Behind the scenes that will resolve to the "*Default" View and as such that is the reference I used for this UIView.
+	 * Although I decided to change "ForceFullscreen" from true to false to get rid of the zoom effect on open/close. */
+	[UIView(ID: "ZoneLootPopup", WantsTileOver: false, ForceFullscreen: false, IgnoreForceFullscreen: false, 
+		NavCategory: "ZoneLootNav", UICanvas: null, TakesScroll: false, UICanvasHost: 0, ForceFullscreenInLegacy: false)]
+	/* Next 2 Views are used for modern UI popups, ref: Qud.UI.PopupMessage
+	 * Using "PopupMessage" for the UICanvas parameter of ZoneLootPopupMessage is intentional! Quote from the documentation (found on CoQ Discord):
+	 * "UICanvas - The name of the UI Canvas (Unity) GameObject which should be displayed when this view is active"
+	 * Changing the UICanvas parameter to e.g. "ZoneLootPopupMessage" would lead to errors since that is not a valid Unity object name */
+	[UIView(ID: "ZoneLootDynamicPopupMessage", WantsTileOver: false, ForceFullscreen: false, IgnoreForceFullscreen: true, 
+		NavCategory: "ZoneLootNav", UICanvas: null, TakesScroll: false, UICanvasHost: 0, ForceFullscreenInLegacy: false)]
+	[UIView(ID: "ZoneLootPopupMessage", WantsTileOver: false, ForceFullscreen: false, IgnoreForceFullscreen: true, 
+		NavCategory: "ZoneLootNav", UICanvas: "PopupMessage", TakesScroll: false, UICanvasHost: 1, ForceFullscreenInLegacy: false)]
 	public class BasePopup {
 		public SortType CurrentSortType;
 		private Dictionary<SortType, List<InventoryItem>> ItemListCache;
@@ -23,7 +32,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 		private static bool s_UIViewsLoaded = false;
 		private static bool s_SwitchToFallback = false;
 		private static bool s_UseFallback = false;
-		internal static bool s_OverridePopup = false;
+		private static bool s_OverridePopup = false;
 
 		private static void SwitchToFallBackCommands() {
 			string oldLayer = "ZoneLootLayer";
@@ -31,9 +40,9 @@ namespace Plaidman.AnEyeForValue.Menus {
 			if (!s_UseFallback && CommandBindingManager.CommandBindingLayers.ContainsKey(oldLayer) && CommandBindingManager.CommandBindingLayers.ContainsKey(newLayer)) {
 				UnityEngine.Debug.LogError("ZoneLootList - Using fallback command settings!");
 				s_UseFallback = true;
-				// Change our commands' attributes to: Layer="UI" and Auto="DownPass"
-				// While certainly suboptimal, this ensures that our commands still work
-				// if our custom UIViews fail for some reason.
+				/* Change our commands' attributes to: Layer="UI" and Auto="DownPass"
+				 * While certainly suboptimal, this ensures that our commands still work
+				 * if our custom UIViews fail for some reason. */
 				foreach (var entry in CommandBindingManager.CommandBindingLayers[oldLayer].actions) {
 					CommandBindingManager.CommandsByID[entry.name].Layer = newLayer;
 					CommandBindingManager.CommandsByID[entry.name].Auto = "DownPass";
@@ -44,8 +53,8 @@ namespace Plaidman.AnEyeForValue.Menus {
 			}
 		}
 
-		internal static bool CheckUIViewsLoaded() {
-			if (s_UIViewsLoaded) {
+		private static bool CheckUIViewsLoaded() {
+			if (s_UIViewsLoaded || s_UseFallback) {
 				// Unloading UIViews isn't possible AFAIK, so we don't have to check again after confirming this once
 				return s_UIViewsLoaded;
 			}
@@ -54,31 +63,33 @@ namespace Plaidman.AnEyeForValue.Menus {
 			bool nav_pzm = GameManager.Instance.HasViewData("ZoneLootPopupMessage");
 
 			// Try to register our custom UIViews if any of them aren't loaded yet.
-			// Should only happen if this mod requires user approval after an update.
+			// Should only happen when this mod requires user approval after an update.
 			if (!nav_zlp || !nav_dzpm || !nav_pzm) {
 				GameManager.Instance.RegisterViews();
 				nav_zlp = GameManager.Instance.HasViewData("ZoneLootPopup");
 				nav_dzpm = GameManager.Instance.HasViewData("ZoneLootDynamicPopupMessage");
 				nav_pzm = GameManager.Instance.HasViewData("ZoneLootPopupMessage");
 
-				// If our custom UIViews still aren't loaded for some reason, switch to fallback command settings
+				// If our custom UIViews still aren't loaded for some reason, switch to fallback command settings.
+				// Note that this NEVER happened in my testing, this is just here as a backup.
 				if (!nav_zlp || !nav_dzpm || !nav_pzm) {
-					// Note that this NEVER happened in my testing, this is just here as a backup.
 					UnityEngine.Debug.LogError("ZoneLootList - Failed to register custom UIViews!");
-					// using UseFallBackCommands() here lead to thread/access errors, so postpone it until next UpdateInput() iteration
+					// Calling SwitchToFallBackCommands() from here lead to threading/access errors,
+					// so set a flag to call it during the next UpdateInput() iteration instead
 					s_SwitchToFallback = true;
+					return false;
 				}
 			}
 			s_UIViewsLoaded = true;
-			return s_UIViewsLoaded;
+			return true;
 		}
 
-		// Replace GameManager::PushGameView()'s GameView parameter when called by Popup::PickOption().
-		// Only this one patch here is required to make our UIViews work with modern UI Popups since
-		// those don't rely on GameManager::UpdateInput() to receive commands (like classic ones do).
-		// This patch could theoretically be avoided by writing our own implementations of Popup::PickOption(),
-		// Popup::WaitNewPopupMessage() and Popup::NewPopupMessageAsync(). But that'd be a lot of code to write
-		// and then also keep up-to-date whenever the game's original functions change.
+		/* Replace GameManager::PushGameView()'s NewView parameter when called by Popup::PickOption().
+		 * Only this one patch here is required to make our UIViews work with modern UI Popups, since
+		 * those don't rely on GameManager::UpdateInput() to receive commands (like classic UI ones do).
+		 * This patch could theoretically be avoided by writing our own implementations of Popup::PickOption(),
+		 * Popup::WaitNewPopupMessage() and Popup::NewPopupMessageAsync(). But that'd be a lot of code to write
+		 * and then also keep up-to-date whenever the game's original functions change. */
 		[HarmonyPatch(typeof(GameManager), nameof(GameManager.PushGameView))]
 		private sealed class PushGameViewPatch {
 			static bool Prefix(ref string NewView) {
@@ -96,9 +107,9 @@ namespace Plaidman.AnEyeForValue.Menus {
 					else if (NewView == "Popup:Choice") {
 						NewView = "ZoneLootPopup";
 					}
-                    else {
-						// This should never happen unless the game's own Popup UIViews get renamed in a future update.
-						// In that unlikely case we'll simply use fallback settings for our commands/keybinds
+					else {
+						// This should never happen unless the game's own UIViews get renamed in a future update.
+						// In that case we'll just use fallback settings for our commands/keybinds until we can fix this proper.
 						UnityEngine.Debug.LogError("ZoneLootList - Unexpected UIView: " + NewView);
 						s_SwitchToFallback = true;
 					}
@@ -107,9 +118,9 @@ namespace Plaidman.AnEyeForValue.Menus {
 			}
 		}
 
-		// Required to make our UIView's keybinds work with classic UI Popups.
-		// Mimics what the game already does for its own layers/navCategories.
-		// Doing it this way lets us avoid having to use Auto="DownPass" for our popup's bindings.
+		/* Required to make our UIView's keybinds work with classic UI Popups.
+		 * Mimics what the game already does for its own layers/navCategories.
+		 * Doing it this way lets us avoid having to use Auto="DownPass" for our popup's bindings. */
 		[HarmonyPatch(typeof(GameManager), nameof(GameManager.UpdateInput))]
 		private sealed class UpdateInputPatch {
 			static void Postfix () {
@@ -121,12 +132,33 @@ namespace Plaidman.AnEyeForValue.Menus {
 					foreach (var entry in CommandBindingManager.CommandBindingLayers[layer].actions) {
 						// All occurences of isCommandDown() inside UpdateInput() use true, false, false for the bool parameters
 						if (ControlManager.isCommandDown(entry.name, true, false, false)) {
+							// Add command to the command queue (all input devices use Keyboard.PushCommand())
 							Keyboard.PushCommand(entry.name, null);
 						}
 					}
-                }
-            }
-        }
+				}
+			}
+		}
+
+		// simple wrapper function for use in ZonePopup/InventoryPopup
+		internal static int PickOption(string Title = "", string Intro = null, IRenderable IntroIcon = null, IReadOnlyList<string> Options = null, bool RespectOptionNewlines = false, 
+			IReadOnlyList<IRenderable> Icons = null, int DefaultSelected = 0, IReadOnlyList<QudMenuItem> Buttons = null, bool AllowEscape = false) {
+			CheckUIViewsLoaded();
+			s_OverridePopup = true; // Set flag to use our custom UIViews for Popup::PickOption()
+			int selectedIndex = Popup.PickOption(
+				Title: Title,
+				Intro: Intro,
+				IntroIcon: IntroIcon,
+				Options: Options,
+				RespectOptionNewlines: RespectOptionNewlines,
+				Icons: Icons,
+				DefaultSelected: DefaultSelected,
+				Buttons: Buttons,
+				AllowEscape: AllowEscape
+			);
+			s_OverridePopup = false; // Should already be false after PickOption(), just adding this here as a backup
+			return selectedIndex;
+		}
 
 		protected void ResetCache() {
 			ItemListCache = new() {

--- a/zone-loot-list/Scripts/General/BasePopup.cs
+++ b/zone-loot-list/Scripts/General/BasePopup.cs
@@ -11,7 +11,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 	// used for classic UI popups, ref: XRL.UI.Popup
 	[UIView("ZoneLootPopup", false, false, false, "ZoneLootNav", null, false, 0, false)]
 	// used for modern UI popups, ref: Qud.UI.PopupMessage
-	// using "PopupMessage" for the UICanvas parameter is intentional! Quote from the documentation (found on CoQ Discord):
+	// using "PopupMessage" for the UICanvas parameter of ZoneLootPopupMessage is intentional! Quote from the documentation (found on CoQ Discord):
 	// UICanvas - The name of the UI Canvas (Unity) GameObject which should be displayed when this view is active
 	[UIView("ZoneLootDynamicPopupMessage", false, false, false, "ZoneLootNav", null, false, 0, false, IgnoreForceFullscreen = true)]
 	[UIView("ZoneLootPopupMessage", false, false, false, "ZoneLootNav", "PopupMessage", false, 0, false, IgnoreForceFullscreen = true, UICanvasHost = 1)]
@@ -23,10 +23,8 @@ namespace Plaidman.AnEyeForValue.Menus {
 		private static bool s_UIViewsLoaded = false;
 		internal static bool s_OverridePopup = false;
 
-		internal static bool Check_UIViewsLoaded()
-        {
-			if (s_UIViewsLoaded)
-            {
+		internal static bool Check_UIViewsLoaded() {
+			if (s_UIViewsLoaded) {
 				// Unloading UIViews isn't possible AFAIK, so we don't have to check again after successfully confirming this once
 				return true;
 			}
@@ -34,18 +32,21 @@ namespace Plaidman.AnEyeForValue.Menus {
 			bool nav_dzpm = GameManager.Instance.HasViewData("ZoneLootDynamicPopupMessage");
 			bool nav_pzm = GameManager.Instance.HasViewData("ZoneLootPopupMessage");
 
-			// Try to register our custom UIViews if any of them aren't loaded yet
-			if (!nav_zlp || !nav_dzpm || !nav_pzm)
-            {
+			// Try to register our custom UIViews if any of them aren't loaded yet.
+			// Should only happen if this mod requires user approval after an update.
+			if (!nav_zlp || !nav_dzpm || !nav_pzm) {
 				GameManager.Instance.RegisterViews();
 				nav_zlp = GameManager.Instance.HasViewData("ZoneLootPopup");
 				nav_dzpm = GameManager.Instance.HasViewData("ZoneLootDynamicPopupMessage");
 				nav_pzm = GameManager.Instance.HasViewData("ZoneLootPopupMessage");
 
 				// If our custom UIViews still aren't loaded for some reason, return false
-				if (!nav_zlp || !nav_dzpm || !nav_pzm)
-				{
+				if (!nav_zlp || !nav_dzpm || !nav_pzm) {
 					UnityEngine.Debug.LogError("ZoneLootList - Failed to register custom UIViews!");
+					// Show error message if our custom UIViews aren't available. Otherwise the game
+					// would fall back to using a generic UIView that doesn't work properly.
+					// Note that this NEVER happened in my testing, this is just here as a backup.
+					Popup.Show("ZoneLootList's UIViews aren't registered! Please restart the game.");
 					return false;
                 }
 			}
@@ -53,31 +54,30 @@ namespace Plaidman.AnEyeForValue.Menus {
 			return true;
 		}
 
+		// Replace GameManager::PushGameView()'s GameView parameter when called by Popup::PickOption().
+		// Only this one patch here is required to make our UIViews work with modern UI Popups since
+		// those don't rely on GameManager::UpdateInput() to receive commands (like classic ones do).
+		// This patch could theoretically be avoided by writing our own implementations of Popup::PickOption(),
+		// Popup::WaitNewPopupMessage() and Popup::NewPopupMessageAsync(). But that'd be a lot of code to write
+		// and then also keep up-to-date whenever the game's original functions change.
 		[HarmonyPatch(typeof(GameManager), nameof(GameManager.PushGameView))]
-		private class PushGameViewPatch
-        {
-			static bool Prefix(ref string NewView)
-			{
+		private sealed class PushGameViewPatch {
+			static bool Prefix(ref string NewView) {
 				// Override NewView with our custom UIView (only when called for by ZonePopup/InventoryPopup), otherwise use original
-				if (s_OverridePopup)
-				{
+				if (s_OverridePopup) {
 					s_OverridePopup = false;
 					// used for modern UI popups, ref: XRL.UI.Popup.WaitNewPopupMessage(...)
-					if (NewView == "PopupMessage")
-					{
+					if (NewView == "PopupMessage") {
 						NewView = "ZoneLootPopupMessage";
 					}
-					else if (NewView == "DynamicPopupMessage")
-					{
+					else if (NewView == "DynamicPopupMessage") {
 						NewView = "ZoneLootDynamicPopupMessage";
 					}
 					// used for classic UI popups, ref: XRL.UI.Popup.PickOption(...)
-					else if (NewView == "Popup:Choice")
-					{
+					else if (NewView == "Popup:Choice") {
 						NewView = "ZoneLootPopup";
 					}
-                    else
-                    {
+                    else {
 						UnityEngine.Debug.LogError("ZoneLootList - Unexpected UIView: " + NewView);
 					}
 				}
@@ -85,35 +85,21 @@ namespace Plaidman.AnEyeForValue.Menus {
 			}
 		}
 
-		// Required to make our UIView work with classic UI Popups
-		// This mimics what the game already does for its own layers/navCategories
+		// Required to make our UIView's keybinds work with classic UI Popups.
+		// Mimics what the game already does for its own layers/navCategories.
+		// Doing it this way lets us avoid having to use Auto="DownPass" for our popup's bindings.
 		[HarmonyPatch(typeof(GameManager), nameof(GameManager.UpdateInput))]
-		private class UpdateInputPatch
-        {
-			static void Postfix (GameManager __instance)
-            {
-				//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch1");
-				if (__instance.CurrentGameView.StartsWith("ZoneLoot"))
-                {
-					string navCat = __instance.GetViewData(__instance.CurrentGameView).NavCategory;
-					string layer = "ZoneLootLayer";
-					//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch2 - " + navCat);
-					//UnityEngine.Debug.LogError(string.Join(", ", CommandBindingManager.CommandBindingLayers));
-					if (navCat == "ZoneLootNav" && CommandBindingManager.CommandBindingLayers.ContainsKey(layer))
-                    {
-						var list = CommandBindingManager.CommandBindingLayers[layer];
-						//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch3");
-						foreach (var entry in list.actions)
-						{
-							if (ControlManager.isCommandDown(entry.name, true, false, false))
-							{
-								//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch4");
-								Keyboard.PushCommand(entry.name, null);
-								//return;
-							}
+		private sealed class UpdateInputPatch {
+			static void Postfix () {
+				string layer = "ZoneLootLayer";
+				if (ControlManager.IsLayerEnabled(layer) && CommandBindingManager.CommandBindingLayers.ContainsKey(layer)) {
+					foreach (var entry in CommandBindingManager.CommandBindingLayers[layer].actions) {
+						// All occurences of isCommandDown() inside UpdateInput() use true, false, false for the bool parameters
+						if (ControlManager.isCommandDown(entry.name, true, false, false)) {
+							Keyboard.PushCommand(entry.name, null);
 						}
 					}
-				}
+                }
             }
         }
 

--- a/zone-loot-list/Scripts/General/BasePopup.cs
+++ b/zone-loot-list/Scripts/General/BasePopup.cs
@@ -1,3 +1,4 @@
+using ConsoleLib.Console;
 using HarmonyLib;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,22 +8,20 @@ namespace Plaidman.AnEyeForValue.Menus {
 	public enum SortType { Weight, Value };
 	public enum PickupType { Single, Multi };
 
-	// used for classic UI popups
-	// ref: XRL.UI.Popup
+	// used for classic UI popups, ref: XRL.UI.Popup
 	[UIView("ZoneLootPopup", false, false, false, "ZoneLootNav", null, false, 0, false)]
-	// used for modern UI popups
-	// ref: Qud.UI.PopupMessage
+	// used for modern UI popups, ref: Qud.UI.PopupMessage
 	// using "PopupMessage" for the UICanvas parameter is intentional! Quote from the documentation (found on CoQ Discord):
 	// UICanvas - The name of the UI Canvas (Unity) GameObject which should be displayed when this view is active
-	[UIView("DynamicZonePopupMessage", false, false, false, "ZoneLootNav", null, false, 0, false, IgnoreForceFullscreen = true)]
-	[UIView("PopupZoneMessage", false, false, false, "ZoneLootNav", "PopupMessage", false, 0, false, IgnoreForceFullscreen = true, UICanvasHost = 1)]
+	[UIView("ZoneLootDynamicPopupMessage", false, false, false, "ZoneLootNav", null, false, 0, false, IgnoreForceFullscreen = true)]
+	[UIView("ZoneLootPopupMessage", false, false, false, "ZoneLootNav", "PopupMessage", false, 0, false, IgnoreForceFullscreen = true, UICanvasHost = 1)]
 	public class BasePopup {
 		public SortType CurrentSortType;
 		private Dictionary<SortType, List<InventoryItem>> ItemListCache;
 		protected Dictionary<SortType, IComparer<InventoryItem>> Comparers;
 
+		private static bool s_UIViewsLoaded = false;
 		internal static bool s_OverridePopup = false;
-		internal static bool s_UIViewsLoaded = false;
 
 		internal static bool Check_UIViewsLoaded()
         {
@@ -32,16 +31,16 @@ namespace Plaidman.AnEyeForValue.Menus {
 				return true;
 			}
 			bool nav_zlp = GameManager.Instance.HasViewData("ZoneLootPopup");
-			bool nav_dzpm = GameManager.Instance.HasViewData("DynamicZonePopupMessage");
-			bool nav_pzm = GameManager.Instance.HasViewData("PopupZoneMessage");
+			bool nav_dzpm = GameManager.Instance.HasViewData("ZoneLootDynamicPopupMessage");
+			bool nav_pzm = GameManager.Instance.HasViewData("ZoneLootPopupMessage");
 
 			// Try to register our custom UIViews if any of them aren't loaded yet
 			if (!nav_zlp || !nav_dzpm || !nav_pzm)
             {
 				GameManager.Instance.RegisterViews();
 				nav_zlp = GameManager.Instance.HasViewData("ZoneLootPopup");
-				nav_dzpm = GameManager.Instance.HasViewData("DynamicZonePopupMessage");
-				nav_pzm = GameManager.Instance.HasViewData("PopupZoneMessage");
+				nav_dzpm = GameManager.Instance.HasViewData("ZoneLootDynamicPopupMessage");
+				nav_pzm = GameManager.Instance.HasViewData("ZoneLootPopupMessage");
 
 				// If our custom UIViews still aren't loaded for some reason, return false
 				if (!nav_zlp || !nav_dzpm || !nav_pzm)
@@ -57,23 +56,23 @@ namespace Plaidman.AnEyeForValue.Menus {
 		[HarmonyPatch(typeof(GameManager), nameof(GameManager.PushGameView))]
 		private class PushGameViewPatch
         {
-			static bool Prefix(ref string NewView, bool bHard)
+			static bool Prefix(ref string NewView)
 			{
-				// Override NewView with our custom UIView once (only when called for by ZonePopup/InventoryPopup), otherwise use original
+				// Override NewView with our custom UIView (only when called for by ZonePopup/InventoryPopup), otherwise use original
 				if (s_OverridePopup)
 				{
 					s_OverridePopup = false;
-					// ref: XRL.UI.Popup.WaitNewPopupMessage(...)
-					if (NewView == "PopupMessage" && bHard)
+					// used for modern UI popups, ref: XRL.UI.Popup.WaitNewPopupMessage(...)
+					if (NewView == "PopupMessage")
 					{
-						NewView = "PopupZoneMessage";
+						NewView = "ZoneLootPopupMessage";
 					}
-					else if (NewView == "DynamicPopupMessage" && bHard)
+					else if (NewView == "DynamicPopupMessage")
 					{
-						NewView = "DynamicZonePopupMessage";
+						NewView = "ZoneLootDynamicPopupMessage";
 					}
-					// ref: XRL.UI.Popup.PickOption(...)
-					else if (NewView == "Popup:Choice" && bHard)
+					// used for classic UI popups, ref: XRL.UI.Popup.PickOption(...)
+					else if (NewView == "Popup:Choice")
 					{
 						NewView = "ZoneLootPopup";
 					}
@@ -85,6 +84,38 @@ namespace Plaidman.AnEyeForValue.Menus {
 				return true; // return control to the original function
 			}
 		}
+
+		// Required to make our UIView work with classic UI Popups
+		// This mimics what the game already does for its own layers/navCategories
+		[HarmonyPatch(typeof(GameManager), nameof(GameManager.UpdateInput))]
+		private class UpdateInputPatch
+        {
+			static void Postfix (GameManager __instance)
+            {
+				//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch1");
+				if (__instance.CurrentGameView.StartsWith("ZoneLoot"))
+                {
+					string navCat = __instance.GetViewData(__instance.CurrentGameView).NavCategory;
+					string layer = "ZoneLootLayer";
+					//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch2 - " + navCat);
+					//UnityEngine.Debug.LogError(string.Join(", ", CommandBindingManager.CommandBindingLayers));
+					if (navCat == "ZoneLootNav" && CommandBindingManager.CommandBindingLayers.ContainsKey(layer))
+                    {
+						var list = CommandBindingManager.CommandBindingLayers[layer];
+						//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch3");
+						foreach (var entry in list.actions)
+						{
+							if (ControlManager.isCommandDown(entry.name, true, false, false))
+							{
+								//UnityEngine.Debug.LogError("ZoneLootList - UpdateInputPatch4");
+								Keyboard.PushCommand(entry.name, null);
+								//return;
+							}
+						}
+					}
+				}
+            }
+        }
 
 		protected void ResetCache() {
 			ItemListCache = new() {

--- a/zone-loot-list/Scripts/General/XMLStrings.cs
+++ b/zone-loot-list/Scripts/General/XMLStrings.cs
@@ -19,8 +19,12 @@ namespace Plaidman.AnEyeForValue.Utils {
 		public static readonly string ChestsOption = "Plaidman_AnEyeForValue_Option_ZoneChests";
 		public static readonly string LiquidsOption = "Plaidman_AnEyeForValue_Option_ZoneLiquids";
 		public static readonly string PureLiquidsOption = "Plaidman_AnEyeForValue_Option_ZonePureLiquids";
+		public static readonly string ClassicUIZoomOption = "Plaidman_AnEyeForValue_Option_ClassicUIZoom";
 
 		public static readonly string PKAppraisalSkill = "PKAPP_Price";
 		public static readonly string AnEyeForValueSkill = "AEFV_AnEyeForValue";
+
+		public const string ZLLCommandLayer = "ZoneLootLayer";
+		public const string ZLLNavCategory = "ZoneLootNav";
 	}
 }

--- a/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
+++ b/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
@@ -50,6 +50,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ "[Selected Weight: {{w|" + (int)weightSelected + "#}}]\xff\xff\xff"
 					+ sortModeString + "\n\n";
 
+				s_OverridePopup = true;
 				int selectedIndex = Popup.PickOption(
 					Title: "Inventory Items",
 					Intro: intro,

--- a/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
+++ b/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
@@ -61,7 +61,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 				}
                 else
                 {
-					s_OverridePopup = true;
+					s_OverridePopup = true; // Use our custom UIView for Popup.PickOption()
 					selectedIndex = Popup.PickOption(
 						Title: "Inventory Items",
 						Intro: intro,

--- a/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
+++ b/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
@@ -50,18 +50,30 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ "[Selected Weight: {{w|" + (int)weightSelected + "#}}]\xff\xff\xff"
 					+ sortModeString + "\n\n";
 
-				s_OverridePopup = true;
-				int selectedIndex = Popup.PickOption(
-					Title: "Inventory Items",
-					Intro: intro,
-					// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'm'),
-					Options: itemLabels,
-					RespectOptionNewlines: false,
-					Icons: itemIcons,
-					DefaultSelected: defaultSelected,
-					Buttons: menuCommands,
-					AllowEscape: true
-				);
+				int selectedIndex;
+				if (!Check_UIViewsLoaded())
+				{
+					// Show error message if our custom UIViews aren't loaded for some reason.
+					// Otherwise the game would fall back to using a generic UIView that doesn't work
+					// with our custom keybind NavCategory
+					Popup.Show("ZoneLootList's UIViews aren't loaded! Please restart the game.");
+					selectedIndex = -1;
+				}
+                else
+                {
+					s_OverridePopup = true;
+					selectedIndex = Popup.PickOption(
+						Title: "Inventory Items",
+						Intro: intro,
+						// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'm'),
+						Options: itemLabels,
+						RespectOptionNewlines: false,
+						Icons: itemIcons,
+						DefaultSelected: defaultSelected,
+						Buttons: menuCommands,
+						AllowEscape: true
+					);
+				}
 
 				switch (selectedIndex) {
 					case -1:  // cancel

--- a/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
+++ b/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
@@ -51,7 +51,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ sortModeString + "\n\n";
 
 				int selectedIndex;
-				if (!Check_UIViewsLoaded()) {
+				if (!CheckUIViewsLoaded()) {
 					selectedIndex = -1;
 				}
                 else {

--- a/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
+++ b/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
@@ -50,25 +50,17 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ "[Selected Weight: {{w|" + (int)weightSelected + "#}}]\xff\xff\xff"
 					+ sortModeString + "\n\n";
 
-				int selectedIndex;
-				if (!CheckUIViewsLoaded()) {
-					selectedIndex = -1;
-				}
-                else {
-					s_OverridePopup = true; // Use our custom UIViews for Popup::PickOption()
-					selectedIndex = Popup.PickOption(
-						Title: "Inventory Items",
-						Intro: intro,
-						// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'm'),
-						Options: itemLabels,
-						RespectOptionNewlines: false,
-						Icons: itemIcons,
-						DefaultSelected: defaultSelected,
-						Buttons: menuCommands,
-						AllowEscape: true
-					);
-					s_OverridePopup = false; // Should already be false after PickOption(), just adding this here as a backup
-				}
+				int selectedIndex = PickOption(
+					Title: "Inventory Items",
+					Intro: intro,
+					// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'm'),
+					Options: itemLabels,
+					RespectOptionNewlines: false,
+					Icons: itemIcons,
+					DefaultSelected: defaultSelected,
+					Buttons: menuCommands,
+					AllowEscape: true
+				);
 
 				switch (selectedIndex) {
 					case -1:  // cancel

--- a/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
+++ b/zone-loot-list/Scripts/LightenMyLoad/InventoryPopup.cs
@@ -51,17 +51,11 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ sortModeString + "\n\n";
 
 				int selectedIndex;
-				if (!Check_UIViewsLoaded())
-				{
-					// Show error message if our custom UIViews aren't loaded for some reason.
-					// Otherwise the game would fall back to using a generic UIView that doesn't work
-					// with our custom keybind NavCategory
-					Popup.Show("ZoneLootList's UIViews aren't loaded! Please restart the game.");
+				if (!Check_UIViewsLoaded()) {
 					selectedIndex = -1;
 				}
-                else
-                {
-					s_OverridePopup = true; // Use our custom UIView for Popup.PickOption()
+                else {
+					s_OverridePopup = true; // Use our custom UIViews for Popup::PickOption()
 					selectedIndex = Popup.PickOption(
 						Title: "Inventory Items",
 						Intro: intro,
@@ -73,6 +67,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 						Buttons: menuCommands,
 						AllowEscape: true
 					);
+					s_OverridePopup = false; // Should already be false after PickOption(), just adding this here as a backup
 				}
 
 				switch (selectedIndex) {

--- a/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
+++ b/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
@@ -74,6 +74,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ sortModeString + "\xff\xff\xff" + pickupModeString + "\n"
 					+ "[Selected weight: {{w|" + (int)weightSelected + "#}}]\n\n";
 
+				s_OverridePopup = true;
 				int selectedIndex = Popup.PickOption(
 					Title: "Lootable Items",
 					Intro: intro,

--- a/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
+++ b/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
@@ -74,25 +74,17 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ sortModeString + "\xff\xff\xff" + pickupModeString + "\n"
 					+ "[Selected weight: {{w|" + (int)weightSelected + "#}}]\n\n";
 
-				int selectedIndex;
-				if (!CheckUIViewsLoaded()) {
-					selectedIndex = -1;
-				}
-                else {
-					s_OverridePopup = true; // Use our custom UIViews for Popup::PickOption()
-					selectedIndex = Popup.PickOption(
-						Title: "Lootable Items",
-						Intro: intro,
-						// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'r'),
-						Options: itemLabels,
-						RespectOptionNewlines: false,
-						Icons: itemIcons,
-						DefaultSelected: defaultSelected,
-						Buttons: menuCommands,
-						AllowEscape: true
-					);
-					s_OverridePopup = false; // Should already be false after PickOption(), just adding this here as a backup
-				}
+				int selectedIndex = PickOption(
+					Title: "Lootable Items",
+					Intro: intro,
+					// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'r'),
+					Options: itemLabels,
+					RespectOptionNewlines: false,
+					Icons: itemIcons,
+					DefaultSelected: defaultSelected,
+					Buttons: menuCommands,
+					AllowEscape: true
+				);
 
 				switch (selectedIndex) {
 					case -1:  // cancel

--- a/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
+++ b/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
@@ -74,7 +74,6 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ sortModeString + "\xff\xff\xff" + pickupModeString + "\n"
 					+ "[Selected weight: {{w|" + (int)weightSelected + "#}}]\n\n";
 
-
 				int selectedIndex;
 				if (!Check_UIViewsLoaded())
 				{
@@ -86,7 +85,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 				}
                 else
                 {
-					s_OverridePopup = true;
+					s_OverridePopup = true; // Use our custom UIView for Popup.PickOption()
 					selectedIndex = Popup.PickOption(
 						Title: "Lootable Items",
 						Intro: intro,

--- a/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
+++ b/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
@@ -74,18 +74,31 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ sortModeString + "\xff\xff\xff" + pickupModeString + "\n"
 					+ "[Selected weight: {{w|" + (int)weightSelected + "#}}]\n\n";
 
-				s_OverridePopup = true;
-				int selectedIndex = Popup.PickOption(
-					Title: "Lootable Items",
-					Intro: intro,
-					// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'r'),
-					Options: itemLabels,
-					RespectOptionNewlines: false,
-					Icons: itemIcons,
-					DefaultSelected: defaultSelected,
-					Buttons: menuCommands,
-					AllowEscape: true
-				);
+
+				int selectedIndex;
+				if (!Check_UIViewsLoaded())
+				{
+					// Show error message if our custom UIViews aren't loaded for some reason.
+					// Otherwise the game would fall back to using a generic UIView that doesn't work
+					// with our custom keybind NavCategory
+					Popup.Show("ZoneLootList's UIViews aren't loaded! Please restart the game.");
+					selectedIndex = -1;
+				}
+                else
+                {
+					s_OverridePopup = true;
+					selectedIndex = Popup.PickOption(
+						Title: "Lootable Items",
+						Intro: intro,
+						// IntroIcon: Renderable.UITile("an_eye_for_value.png", 'y', 'r'),
+						Options: itemLabels,
+						RespectOptionNewlines: false,
+						Icons: itemIcons,
+						DefaultSelected: defaultSelected,
+						Buttons: menuCommands,
+						AllowEscape: true
+					);
+				}
 
 				switch (selectedIndex) {
 					case -1:  // cancel

--- a/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
+++ b/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
@@ -75,7 +75,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ "[Selected weight: {{w|" + (int)weightSelected + "#}}]\n\n";
 
 				int selectedIndex;
-				if (!Check_UIViewsLoaded()) {
+				if (!CheckUIViewsLoaded()) {
 					selectedIndex = -1;
 				}
                 else {

--- a/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
+++ b/zone-loot-list/Scripts/ZoneLootList/ZonePopup.cs
@@ -75,17 +75,11 @@ namespace Plaidman.AnEyeForValue.Menus {
 					+ "[Selected weight: {{w|" + (int)weightSelected + "#}}]\n\n";
 
 				int selectedIndex;
-				if (!Check_UIViewsLoaded())
-				{
-					// Show error message if our custom UIViews aren't loaded for some reason.
-					// Otherwise the game would fall back to using a generic UIView that doesn't work
-					// with our custom keybind NavCategory
-					Popup.Show("ZoneLootList's UIViews aren't loaded! Please restart the game.");
+				if (!Check_UIViewsLoaded()) {
 					selectedIndex = -1;
 				}
-                else
-                {
-					s_OverridePopup = true; // Use our custom UIView for Popup.PickOption()
+                else {
+					s_OverridePopup = true; // Use our custom UIViews for Popup::PickOption()
 					selectedIndex = Popup.PickOption(
 						Title: "Lootable Items",
 						Intro: intro,
@@ -97,6 +91,7 @@ namespace Plaidman.AnEyeForValue.Menus {
 						Buttons: menuCommands,
 						AllowEscape: true
 					);
+					s_OverridePopup = false; // Should already be false after PickOption(), just adding this here as a backup
 				}
 
 				switch (selectedIndex) {

--- a/zone-loot-list/XML/Commands.xml
+++ b/zone-loot-list/XML/Commands.xml
@@ -14,25 +14,25 @@
 		<keyboardBind Modifier="shift" Key="f"/>
 	</command>
 	<command ID="Plaidman_AnEyeForValue_Command_Uninstall" DisplayText="Uninstall Mod" Category="Mod: Zone Loot List" Layer="Adventure" Auto="Down"></command>
-	<command ID="Plaidman_AnEyeForValue_Popup_InvSort" DisplayText="Inv: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_InvSort" DisplayText="Inv: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer">
 		<keyboardBind Modifier="ctrl" Key="tab"/>
 		<gamepadBind Button="select"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_Drop" DisplayText="Inv: Drop Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_Drop" DisplayText="Inv: Drop Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer">
 		<keyboardBind Key="delete"/>
 		<keyboardBind Key="backspace"/>
 		<gamepadBind Alt="true" Button="buttonWest"/>
 		<keyboardBind Key="[" Set="hjkl"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_ZoneSort" DisplayText="Zone: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_ZoneSort" DisplayText="Zone: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" CanShareBindsWith="Plaidman_AnEyeForValue_Popup_InvSort,Plaidman_AnEyeForValue_Popup_Drop">
 		<keyboardBind Modifier="ctrl" Key="tab"/>
 		<gamepadBind Button="select"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_Toggle" DisplayText="Zone: Select All" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_Toggle" DisplayText="Zone: Select All" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" CanShareBindsWith="Plaidman_AnEyeForValue_Popup_InvSort,Plaidman_AnEyeForValue_Popup_Drop">
 		<keyboardBind Key="tab"/>
 		<gamepadBind Button="rightTrigger"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_PickupMode" DisplayText="Zone: Pickup Mode" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_PickupMode" DisplayText="Zone: Pickup Mode" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" CanShareBindsWith="Plaidman_AnEyeForValue_Popup_InvSort,Plaidman_AnEyeForValue_Popup_Drop">
 		<keyboardBind Key="w"/>
 	</command>
 </commands>

--- a/zone-loot-list/XML/Commands.xml
+++ b/zone-loot-list/XML/Commands.xml
@@ -1,7 +1,7 @@
 <commands>
-	<!-- Menus layer is required for Classic UI Escape key -->
-	<!-- UINav layer is required for Modern UI Escape key  -->
-	<!-- ZoneLootLayer is our custom keybind layer -->
+	<!-- Menus layer is required for Classic UI navigation commands (Accept, Cancel, Scrolling, etc.) -->
+	<!-- UINav layer is required for Modern UI navigation commands -->
+	<!-- ZoneLootLayer is our own command/keybind layer -->
 	<navcategory ID="ZoneLootNav">
 		<layer ID="Menus"/>
 		<layer ID="UINav"/>

--- a/zone-loot-list/XML/Commands.xml
+++ b/zone-loot-list/XML/Commands.xml
@@ -14,21 +14,21 @@
 		<keyboardBind Modifier="shift" Key="f"/>
 	</command>
 	<command ID="Plaidman_AnEyeForValue_Command_Uninstall" DisplayText="Uninstall Mod" Category="Mod: Zone Loot List" Layer="Adventure" Auto="Down"></command>
-	<command ID="Plaidman_AnEyeForValue_Popup_InvSort" DisplayText="Inv: Sort Items" Category="Mod: Zone Loot List" Layer="Menus" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_InvSort" DisplayText="Inv: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
 		<keyboardBind Modifier="ctrl" Key="tab"/>
 		<gamepadBind Button="select"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_Drop" DisplayText="Inv: Drop Items" Category="Mod: Zone Loot List" Layer="Menus" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_Drop" DisplayText="Inv: Drop Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
 		<keyboardBind Key="delete"/>
 		<keyboardBind Key="backspace"/>
 		<gamepadBind Alt="true" Button="buttonWest"/>
 		<keyboardBind Key="[" Set="hjkl"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_ZoneSort" DisplayText="Zone: Sort Items" Category="Mod: Zone Loot List" Layer="Menus" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_ZoneSort" DisplayText="Zone: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
 		<keyboardBind Modifier="ctrl" Key="tab"/>
 		<gamepadBind Button="select"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_Toggle" DisplayText="Zone: Select All" Category="Mod: Zone Loot List" Layer="Menus" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_Toggle" DisplayText="Zone: Select All" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
 		<keyboardBind Key="tab"/>
 		<gamepadBind Button="rightTrigger"/>
 	</command>

--- a/zone-loot-list/XML/Commands.xml
+++ b/zone-loot-list/XML/Commands.xml
@@ -1,4 +1,12 @@
 <commands>
+	<!-- Menus layer is required for Classic UI Escape key -->
+	<!-- UINav layer is required for Modern UI Escape key  -->
+	<!-- ZoneLootLayer is our custom keybind layer -->
+	<navcategory ID="ZoneLootNav">
+		<layer ID="Menus"/>
+		<layer ID="UINav"/>
+		<layer ID="ZoneLootLayer"/>
+	</navcategory>
 	<command ID="Plaidman_AnEyeForValue_Command_LightenMyLoad" DisplayText="Show Inventory" Category="Mod: Zone Loot List" Layer="Adventure" Auto="Down">
 		<keyboardBind Modifier="shift" Key="d"/>
 	</command>
@@ -24,7 +32,7 @@
 		<keyboardBind Key="tab"/>
 		<gamepadBind Button="rightTrigger"/>
 	</command>
-	<command ID="Plaidman_AnEyeForValue_Popup_PickupMode" DisplayText="Zone: Pickup Mode" Category="Mod: Zone Loot List" Layer="Menus" Auto="DownPass">
+	<command ID="Plaidman_AnEyeForValue_Popup_PickupMode" DisplayText="Zone: Pickup Mode" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" Auto="DownPass">
 		<keyboardBind Key="w"/>
 	</command>
 </commands>

--- a/zone-loot-list/XML/Commands.xml
+++ b/zone-loot-list/XML/Commands.xml
@@ -15,7 +15,7 @@
 	</command>
 	<command ID="Plaidman_AnEyeForValue_Command_Uninstall" DisplayText="Uninstall Mod" Category="Mod: Zone Loot List" Layer="Adventure" Auto="Down"></command>
 	<command ID="Plaidman_AnEyeForValue_Popup_InvSort" DisplayText="Inv: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer">
-		<keyboardBind Modifier="ctrl" Key="tab"/>
+		<keyboardBind Key="s"/>
 		<gamepadBind Button="select"/>
 	</command>
 	<command ID="Plaidman_AnEyeForValue_Popup_Drop" DisplayText="Inv: Drop Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer">
@@ -25,7 +25,7 @@
 		<keyboardBind Key="[" Set="hjkl"/>
 	</command>
 	<command ID="Plaidman_AnEyeForValue_Popup_ZoneSort" DisplayText="Zone: Sort Items" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" CanShareBindsWith="Plaidman_AnEyeForValue_Popup_InvSort,Plaidman_AnEyeForValue_Popup_Drop">
-		<keyboardBind Modifier="ctrl" Key="tab"/>
+		<keyboardBind Key="s"/>
 		<gamepadBind Button="select"/>
 	</command>
 	<command ID="Plaidman_AnEyeForValue_Popup_Toggle" DisplayText="Zone: Select All" Category="Mod: Zone Loot List" Layer="ZoneLootLayer" CanShareBindsWith="Plaidman_AnEyeForValue_Popup_InvSort,Plaidman_AnEyeForValue_Popup_Drop">

--- a/zone-loot-list/XML/Options.xml
+++ b/zone-loot-list/XML/Options.xml
@@ -31,4 +31,9 @@
 			Makes your character know all item values by default.
 		</helptext>
 	</option>
+	<option ID="Plaidman_AnEyeForValue_Option_ClassicUIZoom" DisplayText="Zoom effect in Classic UI" Category="Mod: Zone Loot List" Type="Checkbox" Default="No">
+		<helptext>
+			Enable/Disable the zoom effect when opening/closing ZLL's windows in Qud's classic UI mode. Has no effect in the modern UI. (Default = Disabled)
+		</helptext>
+	</option>
 </options>

--- a/zone-loot-list/manifest.json
+++ b/zone-loot-list/manifest.json
@@ -2,7 +2,7 @@
 	"id": "Plaidman_AnEyeForValue",
 	"title": "Zone Loot List",
 	"description": "Keep track of which items are known to the player through experience or skill.",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"author": "Plaidman",
 	"tags": "UI/UX,Script,Skill",
 	"previewImage": "preview.png"


### PR DESCRIPTION
This PR makes it possible to use any keybinds we want without impacting the game's own menus/functionality.  
Closes #63 
 
1. Keybinds that were previously on the "Menus" layer are now on their own layer ("ZoneLootLayer"). 
2. Added a new NavCategory ("ZoneLootNav") that is able to receive commands from the new "ZoneLootLayer".
3. Added UIViews that make use of the new "ZoneLootNav" category (2 for modern, 1 for classic UI).
4. Added 2 small Harmony patches to make `Popup::PickOption()` use our UIViews (only when it is called by ZLL).
5. Added fallback functionality in case any part of our UIViews fails (transparent to the end user).
  
Whenever ZLL's `ZonePopup`/`InventoryPopup` call `Popup::PickOption(...)`, the created popup will now use one of our own UIViews and as such will be able to receive commands from the "ZoneLootLayer". This gives us the freedom to use any keybinds we want for ZLL's commands (except for the basic navigation keys like Escape/Up/Down/etc., since those are obviously required for menu navigation). This also made it possible to remove the `Auto="DownPass"` attribute from ZLL's commands, so the game will now properly warn the user if they try to use the same key for two actions in the same ZLL popup. If you have any questions concerning the implementation, just ask away and I'll try to answer them ASAP.
 
As far as I'm concerned, this PR is 100% functional and ready for action. But I'd like to hear your feedback on 2 small details before I do some final cleanup on the last commit/the commit history and mark this PR as ready.  

1. Now that we can use any keybinds, I decided to change the default keybind of the sort command to "s". Can change it back though if that bothers you.  
2. Most popups in CoQ's classic UI mode make use of a zoom in/out effect when they are opened/closed. I've decided to disable this behavior for ZLL's popups in the latest commit. IMO this zoom effect makes the `InventoryPopup` kinda irritating to look at when marking/unmarking items. Would like to hear your preference on this since it is your mod after all. You can add the zoom effect back by changing line 17 of `BasePopup.cs` like this (setting `ForceFullscreen` to `true`):  
```C#
[UIView(ID: "ZoneLootPopup", WantsTileOver: false, ForceFullscreen: true, IgnoreForceFullscreen: false,
```