### PR TITLE
Adds defence against missing factions

### DIFF
--- a/salt-shuffle-revival/Scripts/FactionTracker.cs
+++ b/salt-shuffle-revival/Scripts/FactionTracker.cs
@@ -166,7 +166,7 @@ namespace Plaidman.SaltShuffleRevival {
 			return go.Brain.Allegiance
 				.Where(kvp => {
 					if (Brain.GetAllegianceLevel(kvp.Value) != Brain.AllegianceLevel.Member) return false;
-					return Factions.Get(kvp.Key).Visible;
+					return Factions.GetIfExists(kvp.Key)?.Visible is true;
 				})
 				.Select(kvp => kvp.Key)
 				.ToList();


### PR DESCRIPTION
For cases where a faction once existed but no longer does and a string reference to the missing faction by name still exists in, for example, a creature's brain (`AllegianceSet`).

Addition uses an alternate (base game) method of retrieving the faction by name that simply returns null if it's missing (instead of throwing), and then does the equivalent of `faction != null && faction.Visible` with the result.