### PR TITLE
Uses alternate version of creature display name

### DIFF
--- a/salt-shuffle-revival/Scripts/FactionEntity.cs
+++ b/salt-shuffle-revival/Scripts/FactionEntity.cs
@@ -42,7 +42,7 @@ namespace Plaidman.SaltShuffleRevival {
 		public FactionEntity(GameObject go, bool fromBlueprint) {
 			Blueprint = null;
 
-			Name = go.DisplayNameOnlyDirectAndStripped;
+			Name = go.GetDisplayName(AsIfKnown: true, Single: true, NoConfusion: true, Short: true);
 			Factions = FactionTracker.GetCreatureFactions(go);
 			Strength = go.GetStatValue("Strength");
 			Agility = go.GetStatValue("Agility");


### PR DESCRIPTION
Allows titles and other non-transient name elements (epithets, honorifics, etc.) to appear in card names, along with name colours.

Makes it more obvious who the randomly named cards are when they're a legendary member of their faction, including the card name being coloured under such circumstances.

"Kokoo Koyokoko" becomes "Kokoo Koyokoko legendary albino ape" in the card name.

This is largely a personal aesthetic preference. If you're reluctant to make this change, I'm happy to write a set of options files that implement the change as an optional feature instead.