### PR TITLE
Uses alternate version of creature display name

### DIFF
--- a/salt-shuffle-revival/Scripts/FactionEntity.cs
+++ b/salt-shuffle-revival/Scripts/FactionEntity.cs
@@ -42,7 +42,7 @@ namespace Plaidman.SaltShuffleRevival {
 		public FactionEntity(GameObject go, bool fromBlueprint) {
 			Blueprint = null;
 
-			Name = go.DisplayNameOnlyDirectAndStripped;
+			Name = go.GetDisplayName(AsIfKnown: true, Single: true, NoConfusion: true, Short: true);
 			Factions = FactionTracker.GetCreatureFactions(go);
 			Strength = go.GetStatValue("Strength");
 			Agility = go.GetStatValue("Agility");

--- a/salt-shuffle-revival/Scripts/FactionEntity.cs
+++ b/salt-shuffle-revival/Scripts/FactionEntity.cs
@@ -38,7 +38,10 @@ namespace Plaidman.SaltShuffleRevival {
 
 		public FactionEntity(string blueprint) {
 			Blueprint = blueprint;
-			Name = GameObjectFactory.Factory.GetBlueprint(blueprint).CachedDisplayNameStripped;
+			Name = GameObjectFactory.Factory.GetBlueprint(blueprint).DisplayName();
+            
+            if (!Options.EnableCardNameColors)
+                Name = Name.Strip();
 		}
 
 		public FactionEntity(GameObject go, bool fromBlueprint) {

--- a/salt-shuffle-revival/Scripts/FactionEntity.cs
+++ b/salt-shuffle-revival/Scripts/FactionEntity.cs
@@ -44,7 +44,14 @@ namespace Plaidman.SaltShuffleRevival {
 		public FactionEntity(GameObject go, bool fromBlueprint) {
 			Blueprint = null;
 
-			Name = go.GetDisplayName(AsIfKnown: true, Single: true, NoConfusion: true, Short: true);
+			if (Options.EnableCardLongNames)
+                Name = go.GetDisplayName(AsIfKnown: true, Single: true, NoConfusion: true, Short: true);
+            else
+                Name = go.DisplayNameOnlyDirect;
+            
+            if (!Options.EnableCardNameColors)
+                Name = Name.Strip();
+			
 			Factions = FactionTracker.GetCreatureFactions(go);
 			Strength = go.GetStatValue("Strength");
 			Agility = go.GetStatValue("Agility");

--- a/salt-shuffle-revival/Scripts/Options.cs
+++ b/salt-shuffle-revival/Scripts/Options.cs
@@ -1,0 +1,10 @@
+using System;
+using XRL;
+
+namespace Plaidman.SaltShuffleRevival {
+    [HasOptionFlagUpdate(Prefix = "Plaidman_SaltShuffleRevival_")]
+    public static class Options {
+        [OptionFlag] public static bool EnableCardLongNames;
+        [OptionFlag] public static bool EnableCardNameColors;
+    }
+}

--- a/salt-shuffle-revival/XML/Options.xml
+++ b/salt-shuffle-revival/XML/Options.xml
@@ -7,7 +7,7 @@
   -->
   <option
         ID="Plaidman_SaltShuffleRevival_EnableCardLongNames"
-        DisplayText="Include titles in card names for creatures that have proper names."
+        DisplayText="Include titles in card names for creatures that have proper names"
         Category="Mod: Salt Shuffle Revival"
         Type="Checkbox"
         Default="No">
@@ -16,12 +16,14 @@
       
       &quot;Kokoo Koyokoko&quot; becomes &quot;Kokoo Koyokoko legendary albino ape&quot;
 
+      {{r|Please note}}: only affects cards created after this option is changed.
+
       The default is {{w|Disabled}}.
     </helptext>
   </option>
   <option
         ID="Plaidman_SaltShuffleRevival_EnableCardNameColors"
-        DisplayText="Include name colors in card names for creatures that hame them."
+        DisplayText="Include name colors in card names for creatures that hame them"
         Category="Mod: Salt Shuffle Revival"
         Type="Checkbox"
         Default="No">
@@ -30,6 +32,8 @@
       
       &quot;Kokoo Koyokoko legendary albino ape&quot; becomes &quot;{{M|Kokoo Koyokoko legendary albino ape}}&quot;
       &quot;kaleidoslug&quot; becomes &quot;{{kaleidoslug|kaleidoslug}}&quot;
+
+      {{r|Please note}}: only affects cards created after this option is changed.
 
       The default is {{w|Disabled}}.
     </helptext>

--- a/salt-shuffle-revival/XML/Options.xml
+++ b/salt-shuffle-revival/XML/Options.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<options>
+  <!-- Plaidman_SaltShuffleRevival_ 
+  
+  General Options
+  
+  -->
+  <option
+        ID="Plaidman_SaltShuffleRevival_EnableCardLongNames"
+        DisplayText="Include titles in card names for creatures that have proper names."
+        Category="Mod: Salt Shuffle Revival"
+        Type="Checkbox"
+        Default="No">
+    <helptext>
+      When enabled, if a card depicts a creature whose name includes an honorific, title, epithet, or other non-transient name element, those elements will be included in the card name.
+      
+      &quot;Kokoo Koyokoko&quot; becomes &quot;Kokoo Koyokoko legendary albino ape&quot;
+
+      The default is {{w|Disabled}}.
+    </helptext>
+  </option>
+  <option
+        ID="Plaidman_SaltShuffleRevival_EnableCardNameColors"
+        DisplayText="Include name colors in card names for creatures that hame them."
+        Category="Mod: Salt Shuffle Revival"
+        Type="Checkbox"
+        Default="No">
+    <helptext>
+      When enabled, if a card depicts a creature whose name includes colors, those colors will be included in the card name.
+      
+      &quot;Kokoo Koyokoko legendary albino ape&quot; becomes &quot;{{M|Kokoo Koyokoko legendary albino ape}}&quot;
+      &quot;kaleidoslug&quot; becomes &quot;{{kaleidoslug|kaleidoslug}}&quot;
+
+      The default is {{w|Disabled}}.
+    </helptext>
+  </option>
+</options>


### PR DESCRIPTION
Allows titles and other non-transient name elements (epithets, honorifics, etc.) to appear in card names, along with name colours.

Makes it more obvious who the randomly named cards are when they're a legendary member of their faction, including the card name being coloured under such circumstances.

"Kokoo Koyokoko" becomes "Kokoo Koyokoko legendary albino ape" in the card name.

This is largely a personal aesthetic preference. If you're reluctant to make this change, I'm happy to write a set of options files that implement the change as an optional feature instead.