### PR TITLE
Adds rep bonus to foil and Hero cards when held

### DIFF
--- a/salt-shuffle-revival/Scripts/FactionEntity.cs
+++ b/salt-shuffle-revival/Scripts/FactionEntity.cs
@@ -27,6 +27,8 @@ namespace Plaidman.SaltShuffleRevival {
 		public string DetailColor;
 		public string FgColor;
 		public string Desc;
+        
+        public bool IsHero;
 
 		public bool WantFieldReflection => false;
 		public void Write(SerializationWriter writer) { writer.WriteNamedFields(this, GetType()); }
@@ -43,6 +45,7 @@ namespace Plaidman.SaltShuffleRevival {
 			Blueprint = null;
 
 			Name = go.DisplayNameOnlyDirectAndStripped;
+            IsHero = go.IsHero();
 			Factions = FactionTracker.GetCreatureFactions(go);
 			Strength = go.GetStatValue("Strength");
 			Agility = go.GetStatValue("Agility");

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -122,7 +122,7 @@ namespace XRL.World.Parts {
 			SetDisplayName(fe);
             
             if (!fe.Factions.IsNullOrEmpty() && (Foil || fe.IsHero))
-                AddsRep.AddModifier(ParentObject, fe.Factions.Aggregate("", (a, n) => a + (!a.IsNullOrEmpty() ? "," : null) + n), !fe.IsHero ? 100 : 200);
+                AddsRep.AddModifier(ParentObject, fe.Factions.Aggregate("", (a, n) => a + (!a.IsNullOrEmpty() ? "," : null) + n), !fe.IsHero || !Foil ? 100 : 200);
 		}
 
 		private void NonBlueprintVariance(FactionEntity fe) {

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -121,8 +121,8 @@ namespace XRL.World.Parts {
 			SetDescription(fe);
 			SetDisplayName(fe);
             
-            if (!fe.Factions.IsNullOrEmpty() && (Foil || !fe.FromBlueprint))
-                AddsRep.AddModifier(ParentObject, fe.Factions.Aggregate("", (a, n) => a + (!a.IsNullOrEmpty() ? "," : null) + n), fe.FromBlueprint ? 100 : 200);
+            if (!fe.Factions.IsNullOrEmpty() && (Foil || fe.IsHero))
+                AddsRep.AddModifier(ParentObject, fe.Factions.Aggregate("", (a, n) => a + (!a.IsNullOrEmpty() ? "," : null) + n), !fe.IsHero ? 100 : 200);
 		}
 
 		private void NonBlueprintVariance(FactionEntity fe) {

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -120,6 +120,9 @@ namespace XRL.World.Parts {
 			SetColors(fe);
 			SetDescription(fe);
 			SetDisplayName(fe);
+            
+            if (!fe.Factions.IsNullOrEmpty() && (Foil || !fe.FromBlueprint))
+                AddsRep.AddModifier(ParentObject, fe.Factions.Aggregate("", (a, n) => a + (!a.IsNullOrEmpty() ? "," : null) + n), fe.FromBlueprint ? 100 : 200);
 		}
 
 		private void NonBlueprintVariance(FactionEntity fe) {


### PR DESCRIPTION
Per the title; rep bonuses are as follows:

Foil: +100 to relevant factions.
Named Creature: +100 to relevant factions.
Foil & Named Creature: +200 to relevant factions.

Functions identically to figurines: must be equipped in a hand slot to get the rep bonus.