### PR TITLE
Adds animated foil to foil cards

### DIFF
--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -104,7 +104,7 @@ namespace XRL.World.Parts {
 			int error = xpLevel - (SunScore + MoonScore + StarScore);
 			SunScore += error;
 
-			if (Stat.Rnd2.Next(10) == 0) Foil = true;
+			Foil = Stat.Random(0, 9) == 0;
 			NonBlueprintVariance(fe);
 			BoostLowLevel();
 			BoostFoil();

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -120,6 +120,9 @@ namespace XRL.World.Parts {
 			SetColors(fe);
 			SetDescription(fe);
 			SetDisplayName(fe);
+            
+            if (Foil)
+                ParentObject.RequirePart<UD_AnimatedMaterialFoil>();
 		}
 
 		private void NonBlueprintVariance(FactionEntity fe) {
@@ -191,7 +194,7 @@ namespace XRL.World.Parts {
 			var builder = new StringBuilder();
 
 			if (Foil) {
-				builder.Append("A reflective trading card with an animated illustration of =a==name= plus various cryptic statistics. The card shimmers when viewed at different angles.\n\n");
+				builder.Append("A {{Y|reflective}} trading card with an animated illustration of =a==name= plus various cryptic statistics. The card {{Y|shimmers}} when viewed at different angles.\n\n");
 			} else {
 				builder.Append("A trading card with a stylized illustration of =a==name= plus various cryptic statistics.\n\n");
 			}
@@ -217,9 +220,10 @@ namespace XRL.World.Parts {
 		}
 
 		private void SetDisplayName(FactionEntity fe) {
-			var builder = new StringBuilder("=name= {{W|=sun=}}/{{C|=moon=}}/{{M|=star=}}");
+			var builder = new StringBuilder("=name==foil= {{W|=sun=}}/{{C|=moon=}}/{{M|=star=}}");
 			builder.StartReplace()
 				.AddReplacer("name", fe.Name)
+				.AddReplacer("foil", Foil ? " ({{Y|F}})" : null)
 				.AddReplacer("sun", SunScore.ToString())
 				.AddReplacer("moon", MoonScore.ToString())
 				.AddReplacer("star", StarScore.ToString())

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -104,7 +104,7 @@ namespace XRL.World.Parts {
 			int error = xpLevel - (SunScore + MoonScore + StarScore);
 			SunScore += error;
 
-			Foil = Stat.Random(0, 9) == 0;
+			if (Stat.Rnd2.Next(10) == 0) Foil = true;
 			NonBlueprintVariance(fe);
 			BoostLowLevel();
 			BoostFoil();

--- a/salt-shuffle-revival/Scripts/UD_AnimatedMaterialFoil.cs
+++ b/salt-shuffle-revival/Scripts/UD_AnimatedMaterialFoil.cs
@@ -1,0 +1,155 @@
+﻿using System;
+
+using ConsoleLib.Console;
+
+using XRL.Core;
+using XRL.Rules;
+using XRL.UI;
+
+namespace XRL.World.Parts {
+    [Serializable]
+    public class UD_AnimatedMaterialFoil : IScribedPart {
+        public static int FrameMod = 240;
+        
+        public string OriginalColorString;
+
+        public string OriginalTileColor;
+
+        public string OriginalDetailColor;
+
+        public int FrameOffset;
+
+        public UD_AnimatedMaterialFoil() : base() { }
+
+        public override void Initialize() {
+            if (ParentObject.Render is Render render) {
+                OriginalColorString ??= render.ColorString;
+                OriginalTileColor ??= render.TileColor;
+                OriginalDetailColor ??= render.DetailColor;
+            }
+            base.Initialize();
+        }
+
+        public override void Remove() {
+            if (ParentObject.Render is Render render)
+            {
+                if (!OriginalTileColor.IsNullOrEmpty())
+                    render.TileColor = OriginalTileColor;
+
+                if (!OriginalColorString.IsNullOrEmpty())
+                    render.ColorString = OriginalColorString;
+
+                if (!OriginalDetailColor.IsNullOrEmpty())
+                    render.DetailColor = OriginalDetailColor;
+            }
+            base.Remove();
+        }
+
+        public string GetOtherShade(string Color) {
+            if (Color.IsNullOrEmpty())
+                return "y";
+            
+            string strippedColor = Color.Replace("&", "");
+
+            string bright = strippedColor.ToUpper();
+            string dark = strippedColor.ToLower();
+
+            return $"{(strippedColor != Color ? "&" : null)}{(strippedColor == bright ? dark : bright)}";
+        }
+        
+        public string GetTileOtherShade()
+            => GetOtherShade(GetOriginalTileColor())
+            ;
+        
+        public string GetDetailOtherShade()
+            => GetOtherShade(OriginalDetailColor)
+            ;
+
+        public string GetAlternateColor(string BasedOn, string Except = null) {
+            string except = Except.Replace("&", "");
+            if (BasedOn.ToUpper() != BasedOn && except != "Y")
+                return "Y";
+            
+            return except != "y" ? "y" : "Y";
+        }
+        
+        public string GetOriginalTileColor() {
+            if (OriginalTileColor.IsNullOrEmpty())
+                return ColorUtility.StripBackgroundFormatting(OriginalColorString);
+            
+            return OriginalTileColor;
+        }
+
+        public override bool Render(RenderEvent E) {
+            if (ParentObject.Render is Render render) {
+                int frame = (XRLCore.CurrentFrame + FrameOffset + (ParentObject?.BaseID ?? 0)) % FrameMod;
+
+                string tileColor = null;
+                string colorString = null;
+                string detailColor = null;
+
+                if (frame < 16) {
+                    tileColor = GetTileOtherShade();
+                    colorString = tileColor;
+                    
+                    detailColor = GetAlternateColor(BasedOn: OriginalDetailColor, Except: tileColor);
+                    if (tileColor.Replace("&", "") == detailColor)
+                        detailColor = GetOtherShade(detailColor);
+                }
+                else if (frame < 32) {
+                    detailColor = GetDetailOtherShade();
+                    
+                    tileColor = $"&{GetAlternateColor(BasedOn: GetOriginalTileColor(), Except: detailColor)}";
+                    if (tileColor.Replace("&", "") == detailColor)
+                        tileColor = GetOtherShade(tileColor);
+                    colorString = tileColor;
+                }
+                else if (frame < 64) {
+                    detailColor = GetDetailOtherShade();
+                    
+                    tileColor = GetOriginalTileColor();
+                    if (tileColor.Replace("&", "") == detailColor)
+                        tileColor = GetOtherShade(tileColor);
+                    colorString = tileColor;
+                }
+                else {
+                    tileColor = GetOriginalTileColor();
+                    colorString = tileColor;
+                    
+                    detailColor = OriginalDetailColor;
+                    if (tileColor.Replace("&", "") == detailColor)
+                        detailColor = GetOtherShade(detailColor);
+                }
+
+                if (!tileColor.IsNullOrEmpty())
+                    render.TileColor = tileColor;
+
+                if (!colorString.IsNullOrEmpty())
+                    render.ColorString = colorString;
+
+                if (!detailColor.IsNullOrEmpty())
+                    render.DetailColor = detailColor;
+
+                if (!Options.DisableTextAnimationEffects)
+                    FrameOffset += Math.Max(0, Stat.RandomCosmetic(-2, 3));
+
+                return true;
+            }
+            return base.Render(E);
+        }
+        
+        public override bool WantEvent(int ID, int Cascade)
+            => base.WantEvent(ID, Cascade)
+            || ID == GetDebugInternalsEvent.ID
+            ;
+            
+            
+        public override bool HandleEvent(GetDebugInternalsEvent E) {
+            E.AddEntry(this, nameof(FrameOffset), FrameOffset);
+            E.AddEntry(this, nameof(OriginalColorString), OriginalColorString);
+            E.AddEntry(this, nameof(OriginalTileColor), OriginalTileColor);
+            E.AddEntry(this, nameof(OriginalDetailColor), OriginalDetailColor);
+            return base.HandleEvent(E);
+        }
+    }
+}


### PR DESCRIPTION
Animation has a relatively short animation cycle that plays over the first second of every 4.
Alternates the object's colors between bright and dark, occasionally putting white or grey in instead.
Makes the object look like it's shimmering a little, but not constantly.

Also adds an (F) to foil card names so that they can be identified as foils from their display name.

Adds a minor white coloration to some words in a foil card's description.