### PR TITLE
Adds `Lovely` part to cards originating from objects that also have the `Lovely` part

### DIFF
--- a/salt-shuffle-revival/Scripts/FactionEntity.cs
+++ b/salt-shuffle-revival/Scripts/FactionEntity.cs
@@ -27,6 +27,8 @@ namespace Plaidman.SaltShuffleRevival {
 		public string DetailColor;
 		public string FgColor;
 		public string Desc;
+		
+        public bool IsLovely;
 
 		public bool WantFieldReflection => false;
 		public void Write(SerializationWriter writer) { writer.WriteNamedFields(this, GetType()); }
@@ -53,6 +55,7 @@ namespace Plaidman.SaltShuffleRevival {
 			Level = go.GetStatValue("Level");
 			Tier = go.GetTier();
 			IsBaetyl = go.Brain?.GetPrimaryFaction() == "Baetyl";
+            IsLovely = go.HasPart<Lovely>();
 			a = go.a;
 			DetailColor = go.Render.DetailColor;
 			FgColor = ColorUtility.StripBackgroundFormatting(go.Render.ColorString);

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -120,6 +120,11 @@ namespace XRL.World.Parts {
 			SetColors(fe);
 			SetDescription(fe);
 			SetDisplayName(fe);
+            
+            if (fe.IsLovely)
+                ParentObject.RequirePart<Lovely>();
+            else
+                ParentObject.RemovePart<Lovely>();
 		}
 
 		private void NonBlueprintVariance(FactionEntity fe) {


### PR DESCRIPTION
Adds the `Lovely` part that Apple Farmer's Daughters have that makes you lovesick when you look at them _if_ the faction entity object has that part.

Explicitly removes the part if it is present despite the originating object lacking it.

This is the same behaviour as the base game with figurines and statues.

I am _so_ sorry for the pull request spam. I think I'm *actually* done now.