### PR TITLE
Definable Cards (and Boosters) Patch

### DIFF
--- a/salt-shuffle-revival/Scripts/BoosterPack.cs
+++ b/salt-shuffle-revival/Scripts/BoosterPack.cs
@@ -39,11 +39,20 @@ namespace XRL.World.Parts {
 				Faction = null;
 				ParentObject.DisplayName = "Salt Shuffle starter deck";
 			} else {
-				OverrideFaction(FactionTracker.GetRandomFaction());
+                // this allows for object blueprints that inherit from Plaidman_SSR_Booster to specify a faction
+                if (Faction.IsNullOrEmpty())
+                    Faction = FactionTracker.GetRandomFaction();
+                else
+                    Faction = FactionTracker.ClosestFaction(Faction);
+                OverrideFaction(Faction);
 			}
-
 			return base.HandleEvent(e);
 		}
+
+        // forces no stacking
+        public override bool SameAs(IPart p)
+            => false
+            ;
 
 		public void OverrideFaction(string faction) {
 			Faction = faction;

--- a/salt-shuffle-revival/Scripts/CardPouch.cs
+++ b/salt-shuffle-revival/Scripts/CardPouch.cs
@@ -33,6 +33,11 @@ namespace XRL.World.Parts {
 
 			ParentObject.CurrentCell.AddObject(pouch);
 			return base.HandleEvent(e);
-		}
-	}
+        }
+
+        // forces no stacking
+        public override bool SameAs(IPart p)
+            => false
+            ;
+    }
 }

--- a/salt-shuffle-revival/Scripts/FactionEntity.cs
+++ b/salt-shuffle-revival/Scripts/FactionEntity.cs
@@ -6,7 +6,7 @@ using XRL.World.Parts;
 
 namespace Plaidman.SaltShuffleRevival {
 	[Serializable]
-	public class FactionEntity : IComposite {
+	public class FactionEntity : IComposite, IDisposable {
 		public readonly string Blueprint;
 		public bool FromBlueprint;
 		public string Name;
@@ -67,6 +67,36 @@ namespace Plaidman.SaltShuffleRevival {
 				// traipsing mortar was having issues getting description in game init, so we just default to the non-minevented short description
 				Desc = ColorUtility.StripFormatting(go.GetPart<Description>()._Short);
 			}
+
+            // if the game object was created explicitly to create this FE, it should be tidied up
+            if (FromBlueprint) go.Obliterate();
+        }
+
+		protected FactionEntity(FactionEntity fe) {
+			Blueprint = fe.Blueprint;
+
+			Name = fe.Name;
+			Factions = fe.Factions;
+
+			Strength = fe.Strength;
+			Agility = fe.Agility;
+			Toughness = fe.Toughness;
+			Intelligence = fe.Intelligence;
+			Ego = fe.Ego;
+			Willpower = fe.Willpower;
+
+			Level = fe.Level;
+			Tier = fe.Tier;
+
+			IsBaetyl = fe.IsBaetyl;
+            IsLovely = fe.IsLovely;
+
+			a = fe.a;
+			DetailColor = fe.DetailColor;
+			FgColor = fe.FgColor;
+			FromBlueprint = fe.FromBlueprint;
+
+			Desc = fe.Desc;
 		}
 
 		public FactionEntity GetCreature() {
@@ -78,8 +108,42 @@ namespace Plaidman.SaltShuffleRevival {
 			return this;
 		}
 
+		public static FactionEntity GetCreature(string blueprint) {
+			using var blueprintFE = new FactionEntity(blueprint);
+			return blueprintFE.GetCreature();
+        }
+
+		public FactionEntity Clone() {
+			return new FactionEntity(this);
+		}
+
 		public bool Equals(FactionEntity other) {
 			return Name == other.Name && Tier == other.Tier;
 		}
-	}
+
+        public void Dispose() {
+            Name = null;
+            Factions = null;
+
+            Strength = 0;
+            Agility = 0;
+            Toughness = 0;
+            Intelligence = 0;
+            Ego = 0;
+            Willpower = 0;
+
+            Level = 0;
+            Tier = 0;
+
+            IsBaetyl = false;
+            IsLovely = false;
+
+            a = null;
+            DetailColor = null;
+            FgColor = null;
+            FromBlueprint = false;
+
+            Desc = null;
+        }
+    }
 }

--- a/salt-shuffle-revival/Scripts/FactionTracker.cs
+++ b/salt-shuffle-revival/Scripts/FactionTracker.cs
@@ -160,6 +160,31 @@ namespace Plaidman.SaltShuffleRevival {
 			return GetFactionMembers(faction).GetRandomElementCosmetic().GetCreature();
 		}
 
+		public static FactionEntity RequireEntity(string blueprint) {
+			if (GameObjectFactory.Factory.GetBlueprintIfExists(blueprint) is not GameObjectBlueprint model)
+				return null;
+
+			var instance = GetInstance();
+			// sample disposes itself at the end of scope
+            using var sampleEntity = FactionEntity.GetCreature(model.Name);
+
+            foreach (var feList in instance.FactionMemberCache.Values) {
+				if (feList.FirstOrDefault(fe => fe.Equals(sampleEntity)) is FactionEntity existingEntity) {
+                    return existingEntity;
+                }
+			}
+
+			// not using, so entity will persist
+			var entity = sampleEntity.Clone();
+            foreach (var faction in entity.Factions) {
+				var factionMembers = GetFactionMembers(faction);
+				if (factionMembers.Any(member => member.Equals(sampleEntity))) continue;
+				factionMembers.Add(entity);
+            }
+
+            return entity;
+		}
+
 		public static List<string> GetCreatureFactions(GameObject go) {
 			if (go.Brain == null) return new();
 

--- a/salt-shuffle-revival/Scripts/FactionTracker.cs
+++ b/salt-shuffle-revival/Scripts/FactionTracker.cs
@@ -160,29 +160,29 @@ namespace Plaidman.SaltShuffleRevival {
 			return GetFactionMembers(faction).GetRandomElementCosmetic().GetCreature();
 		}
 
-		public static FactionEntity RequireEntity(string blueprint) {
+		public static FactionEntity RequireCreature(string blueprint) {
 			if (GameObjectFactory.Factory.GetBlueprintIfExists(blueprint) is not GameObjectBlueprint model)
 				return null;
 
 			var instance = GetInstance();
+
 			// sample disposes itself at the end of scope
             using var sampleEntity = FactionEntity.GetCreature(model.Name);
 
             foreach (var feList in instance.FactionMemberCache.Values) {
 				if (feList.FirstOrDefault(fe => fe.Equals(sampleEntity)) is FactionEntity existingEntity) {
-                    return existingEntity;
+                    return existingEntity.GetCreature();
                 }
 			}
 
-			// not using, so entity will persist
-			var entity = sampleEntity.Clone();
-            foreach (var faction in entity.Factions) {
-				var factionMembers = GetFactionMembers(faction);
-				if (factionMembers.Any(member => member.Equals(sampleEntity))) continue;
-				factionMembers.Add(entity);
+            var entity = sampleEntity.Clone();
+            foreach (var faction in entity.Factions)
+            {
+                var factionMembers = GetFactionMembers(faction);
+                if (factionMembers.Any(member => member.Equals(entity))) continue;
+                factionMembers.Add(entity);
             }
-
-            return entity;
+            return entity.GetCreature();
 		}
 
 		public static List<string> GetCreatureFactions(GameObject go) {

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -57,7 +57,7 @@ namespace XRL.World.Parts {
 				SetCreature(FactionTracker.GetRandomCreature());
             // if Blueprint is defined in the object blueprint, find the FE for it, set it; fall back to random creature
             } else if (!Blueprint.IsNullOrEmpty()) {
-				if (FactionTracker.RequireEntity(Blueprint) is FactionEntity blueprintFE) {
+				if (FactionTracker.RequireCreature(Blueprint) is FactionEntity blueprintFE) {
 					SetCreature(blueprintFE);
 				} else {
 					SetCreature(FactionTracker.GetRandomCreature());

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -13,6 +13,9 @@ namespace XRL.World.Parts {
 		public int PointValue = 0;
 		public string ShortDisplayName = "";
 		public bool Foil = false;
+		public bool Random;
+		public string Faction;
+		public string Blueprint;
 
 		public override void Read(GameObject basis, SerializationReader reader) {
 			if (reader.ModVersions["Plaidman_SaltShuffleRevival"] == new Version("1.0.0")) {
@@ -32,6 +35,7 @@ namespace XRL.World.Parts {
 			registrar.Register(ObjectCreatedEvent.ID);
 			registrar.Register(GetIntrinsicValueEvent.ID);
 			registrar.Register(The.Game, SSR_UninstallEvent.ID);
+			registrar.Register(GetDebugInternalsEvent.ID);
 			base.Register(go, registrar);
 		}
 
@@ -48,9 +52,38 @@ namespace XRL.World.Parts {
 		}
 
 		public override bool HandleEvent(ObjectCreatedEvent e) {
-			ParentObject.SetIntProperty("NeverStack", 1);
+            // if Random is set true in the object blueprint, find a random creature, set it
+			if (Random) {
+				SetCreature(FactionTracker.GetRandomCreature());
+            // if Blueprint is defined in the object blueprint, find the FE for it, set it; fall back to random creature
+            } else if (!Blueprint.IsNullOrEmpty()) {
+				if (FactionTracker.RequireEntity(Blueprint) is FactionEntity blueprintFE) {
+					SetCreature(blueprintFE);
+				} else {
+					SetCreature(FactionTracker.GetRandomCreature());
+				}
+			// if Faction is defined in the object blueprint, find a random FE for it, set it; fall back to random creature
+			} else if (!Faction.IsNullOrEmpty()) {
+				if (FactionTracker.GetRandomCreature(Faction) is FactionEntity factionFE) {
+					SetCreature(factionFE);
+				} else {
+					SetCreature(FactionTracker.GetRandomCreature());
+				}
+			}
 			return base.HandleEvent(e);
 		}
+
+		public override bool HandleEvent(GetDebugInternalsEvent e) {
+			e.AddEntry(this, nameof(ParentObject), ParentObject.Blueprint);
+			e.AddEntry(this, nameof(Faction), Faction ?? "undefined");
+			e.AddEntry(this, nameof(Blueprint), Blueprint ?? "undefined");
+			return base.HandleEvent(e);
+        }
+
+        // forces no stacking
+        public override bool SameAs(IPart p)
+            => false
+            ;
 
 		// opening a starter deck
 		public static GameObject CreateCard() {
@@ -116,6 +149,8 @@ namespace XRL.World.Parts {
 			}
 
 			PointValue = SunScore + MoonScore + StarScore;
+
+			Faction = fe.Factions.FirstOrDefault();
 
 			SetColors(fe);
 			SetDescription(fe);

--- a/salt-shuffle-revival/Scripts/TradingCard.cs
+++ b/salt-shuffle-revival/Scripts/TradingCard.cs
@@ -75,6 +75,7 @@ namespace XRL.World.Parts {
 
 		public override bool HandleEvent(GetDebugInternalsEvent e) {
 			e.AddEntry(this, nameof(ParentObject), ParentObject.Blueprint);
+			e.AddEntry(this, nameof(Random), Random);
 			e.AddEntry(this, nameof(Faction), Faction ?? "undefined");
 			e.AddEntry(this, nameof(Blueprint), Blueprint ?? "undefined");
 			return base.HandleEvent(e);

--- a/salt-shuffle-revival/XML/ObjectBlueprints.xml
+++ b/salt-shuffle-revival/XML/ObjectBlueprints.xml
@@ -1,15 +1,15 @@
 <objects>
 	<object Name="Plaidman_SSR_Booster" Inherits="Item">
-		<part Name="Render" Tile="items/SSR_Booster.png" DetailColor="O" ColorString="&amp;C" />
+		<part Name="Render" DisplayName="[Salt Shuffle Booster]" Tile="items/SSR_Booster.png" DetailColor="O" ColorString="&amp;C" />
 		<part Name="Physics" Weight="1" Category="Trading Cards" />
 		<part Name="SSR_BoosterPack" />
 		<part Name="Description" Short="A pack of five Salt Shuffle cards, all belonging to one specific faction." />
 		<part Name="Commerce" Value="6" />
 		<part Name="NoRust" />
+    <intproperty Name="NeverStack" Value="1" />
 	</object>
-	<object Name="Plaidman_SSR_Starter" Inherits="Item">
-		<part Name="Render" Tile="items/SSR_Booster.png" DetailColor="W" ColorString="&amp;y" />
-		<part Name="Physics" Weight="1" Category="Trading Cards" />
+	<object Name="Plaidman_SSR_Starter" Inherits="Plaidman_SSR_Booster">
+		<part Name="Render" DisplayName="Salt Shuffle starter deck" DetailColor="W" ColorString="&amp;y" />
 		<part Name="SSR_BoosterPack" Starter="true" />
 		<part Name="Description" Short="A pack of twelve random Salt Shuffle cards, enough to get started playing the game." />
 		<part Name="Commerce" Value="0" />
@@ -21,9 +21,11 @@
 		<part Name="Description" Short="A Salt Shuffle card. Fingerprint smudges make it hard to read." />
 		<part Name="Physics" Weight="0" Category="Trading Cards" />
 		<part Name="Commerce" Value="1" />
-		<tag Name="ExcludeFromDynamicEncounters" />
+		<tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+    <tag Name="BaseObject" Value="*noinherit" />
 		<tag Name="NoSparkingQuest" />
 		<part Name="NoRust" />
+    <intproperty Name="NeverStack" Value="1" />
 	</object>
 	<object Name="Plaidman_SSR_CardPouch" Inherits="Chest">
 		<part Name="Description" Short="A small leather reusable pouch perfectly sized to store Salt Shuffle cards. There is a small spot of blood on the flap." />
@@ -32,23 +34,79 @@
 		<part Name="Physics" Weight="1" Category="Trading Cards" />
 		<tag Name="ExcludeFromDynamicEncounters" />
 		<tag Name="NoSparkingQuest" />
+    <intproperty Name="NeverStack" Value="1" />
 	</object>
 	<object Name="Plaidman_SSR_BoosterBox" Inherits="Chest">
 		<part Name="Description" Short="A box of ten assorted Salt Shuffle card packs." />
 		<part Name="Render" DisplayName="Salt Shuffle booster box" />
 		<part Name="Physics" Weight="1" Category="Trading Cards" />
-		<!-- Number="10" generates 10x of the same faction -->
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
-		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="1" />
+		<inventoryobject Blueprint="Plaidman_SSR_Booster" Number="10" />
 		<tag Name="ExcludeFromDynamicEncounters" />
 		<tag Name="NoSparkingQuest" />
+    <intproperty Name="NeverStack" Value="1" />
 	</object>
+
+  <!-- Pretty literally any cached FactionEntity -->
+  <object Name="Plaidman_SSR_Card Random" Inherits="Plaidman_SSR_Card">
+    <part Name="SSR_Card" Random="true" />
+  </object>
+
+  <!--
+		Specific cards
+    Mostly for example so excluded from dynamic tables, but able to be wished in via blueprint alone
+  -->
+  <object Name="Plaidman_SSR_Card Faction Wardens" Inherits="Plaidman_SSR_Card">
+    <part Name="SSR_Card" Faction="Wardens" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+
+  <object Name="Plaidman_SSR_Card Faction Dromad" Inherits="Plaidman_SSR_Card">
+    <part Name="SSR_Card" Faction="Dromad" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+
+  <object Name="Plaidman_SSR_Card Warden Une" Inherits="Plaidman_SSR_Card">
+    <part Name="SSR_Card" Blueprint="Une" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+
+  <object Name="Plaidman_SSR_Card Snapjaw Scavenger" Inherits="Plaidman_SSR_Card">
+    <part Name="SSR_Card" Blueprint="Snapjaw Scavenger" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+  
+  <!--
+		Specific boosters
+    Mostly for example so excluded from dynamic tables, but able to be wished in via blueprint alone
+  -->
+  <object Name="Plaidman_SSR_Booster YdFreehold" Inherits="Plaidman_SSR_Booster">
+    <part Name="Render" DisplayName="[Salt Shuffle booster: YdFreehold]" />
+    <part Name="SSR_BoosterPack" Faction="YdFreehold" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+
+  <object Name="Plaidman_SSR_Booster Trees" Inherits="Plaidman_SSR_Booster">
+    <part Name="Render" DisplayName="[Salt Shuffle booster: Trees]" />
+    <part Name="SSR_BoosterPack" Faction="Trees" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+
+  <object Name="Plaidman_SSR_Booster Strangers" Inherits="Plaidman_SSR_Booster">
+    <part Name="Render" DisplayName="[Salt Shuffle booster: Strangers]" />
+    <part Name="SSR_BoosterPack" Faction="Strangers" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+
+  <object Name="Plaidman_SSR_Booster Fish" Inherits="Plaidman_SSR_Booster">
+    <part Name="Render" DisplayName="[Salt Shuffle booster: Fish]" />
+    <part Name="SSR_BoosterPack" Faction="Fish" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+
+  <object Name="Plaidman_SSR_Booster Barathrumites" Inherits="Plaidman_SSR_Booster">
+    <part Name="Render" DisplayName="[Salt Shuffle booster: Barathrumites]" />
+    <part Name="SSR_BoosterPack" Faction="Barathrumites" />
+    <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
+  </object>
+  
 </objects>

--- a/salt-shuffle-revival/XML/PopulationTables.xml
+++ b/salt-shuffle-revival/XML/PopulationTables.xml
@@ -4,45 +4,53 @@
 			<object Blueprint="Plaidman_SSR_Starter" Number="1"></object>
 		</group>
 	</population>
+  
+  <population Name="Plaidman_SSR Booster Or Cards">
+    <group Name="Items" Style="pickone">
+      <object Weight="10" Number="1" Blueprint="Plaidman_SSR_Booster" />
+      <object Weight="10" Number="2-5" Blueprint="Plaidman_SSR_Card Random" />
+      <table Weight="1" Number="2" Name="Plaidman_SSR Booster Or Cards" />
+    </group>
+  </population>
 
 	<population Name="Trinkets 1">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+			<table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 	<population Name="Trinkets 2">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+      <table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 	<population Name="Trinkets 3">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+			<table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 	<population Name="Trinkets 4">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+      <table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 	<population Name="Trinkets 5">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+      <table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 	<population Name="Trinkets 6">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+      <table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 	<population Name="Trinkets 7">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+      <table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 	<population Name="Trinkets 8">
 		<group Name="Items" Style="pickone">
-			<object Weight="35" Number="1" Blueprint="Plaidman_SSR_Booster" />
+      <table Weight="35" Number="1" Name="Plaidman_SSR Booster Or Cards" />
 		</group>
 	</population>
 </populations>


### PR DESCRIPTION
This patch implements some relatively minor changes and a few small additions that support the ability to define trading card object blueprints without depending on a booster pack to create the card in question.

### Cards
Adds the following part parameters to `SSR_Card` in order of priority:
- `Random`, boolean, does what's on the tin (same as drawn from a starter)
- `Faction`, same as when drawn from a faction booster
- `Blueprint`, uses new `FactionTracker` method to get a `FactionEntity` for the supplied blueprint

`Faction` must be the name of one of the game's factions, and be otherwise eligible according to the `FactionTracker`.

`Blueprint` must be the name of a valid, existing, faction-having `GameObjectBlueprint`.

If `Random` is set true, `Faction` and `Blueprint` are ignored.
If `Faction` is defined (at all, even with an invalid value), `Blueprint` is ignored.
If `Faction` or `Blueprint` is defined but not valid, it falls back to a totally random creature.
(An invalid `Faction` with a _valid_ `Blueprint` will still be random, because `Faction` takes precedent)

There are example blueprints for these, excluded from dynamic encounters.
- `"Plaidman_SSR_Card Random"` produces a random card. **Not** excluded from dynamic encounters.
- `"Plaidman_SSR_Card Faction Wardens"` produces a Wardens faction card.
- `"Plaidman_SSR_Card Faction Dromad"` produces a Dromad faction card.
- `"Plaidman_SSR_Card Warden Une"` produces an Une card.
- `"Plaidman_SSR_Card Snapjaw Scavenger"` produces a snapjaw scavenger card.

Example definitions:
```xml
<object Name="Plaidman_SSR_Card Faction Wardens" Inherits="Plaidman_SSR_Card">
  <part Name="SSR_Card" Faction="Wardens" />
  <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
</object>
```
```xml
<object Name="Plaidman_SSR_Card Snapjaw Scavenger" Inherits="Plaidman_SSR_Card">
  <part Name="SSR_Card" Blueprint="Snapjaw Scavenger" />
  <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
</object>
```
### Boosters
The `Faction` part parameter that already existed for `SSR_BoosterPack` is now respected if it's defined in an object blueprint.

As above, it falls back to a random faction if it's undefined. It tries to find the closest faction before committing to one, per `FactionTracker.ClosestFaction`.

There are example blueprints for these, all excluded from dynamic encounters, all fairly self explanitory.
- `"Plaidman_SSR_Booster YdFreehold"`
- `"Plaidman_SSR_Booster Trees"`
- `"Plaidman_SSR_Booster Strangers"`
- `"Plaidman_SSR_Booster Fish"`
- `"Plaidman_SSR_Booster Barathrumites"`

Example definition:
```xml
<object Name="Plaidman_SSR_Booster YdFreehold" Inherits="Plaidman_SSR_Booster">
  <part Name="Render" DisplayName="[Salt Shuffle booster: YdFreehold]" />
  <part Name="SSR_BoosterPack" Faction="YdFreehold" />
  <tag Name="ExcludeFromDynamicEncounters" Value="*noinherit" />
</object>
```
### Closing
The above example blueprints can all be wished for via blueprint name, but, more importantly, **used in population tables** (such as for special merchants that exclusively sell cards/boosters).

Provided there's a blueprint defined for them, boosters of various factions can be weighted higher or lower in hypothetical merchant-wares population tables.

It wouldn't take much to integrate with the additions in https://github.com/plaidman/qud-mods/pull/75, https://github.com/plaidman/qud-mods/pull/71, or https://github.com/plaidman/qud-mods/pull/69, which, I'm more than happy to do myself if both this and any of those patches are something you'd like (or plan) to add.
________

From the commit:
- Implements ability to specify Random, Faction, or Blueprint when defining a Trading Card object blueprint.
  - Non-dynamic examples included.
- Adds ability to specify Faction when defining a Booster Pack object blueprint.
  - Non-dynamic examples included.
- Adds the `IDisposable` pattern to `FactionEntity` so that they can be used with the `using` keyword where it makes sense to do so.
- Moves "NeverStack" to blueprint definition for Trading Card.
- Adds "NeverStack" to blueprint definition for Booster and Card Pouch.
- Supports "NeverStack" with `IPart.SameAs(IPart)` override.
- Adds method to Require a `FactionEntity` from a supplied bluepriunt name. Only returns null if the blueprint doesn't exist.
- Adds handling of `GetDebugInternalsEvent` for `SSR_Card` to better monitor the part parameters passed to a card from its blueprint.